### PR TITLE
Remove obsolete continue comments

### DIFF
--- a/script_vpc_config_per_peer.py
+++ b/script_vpc_config_per_peer.py
@@ -24,13 +24,10 @@ try:
     net_connect = ConnectHandler(**N9K)
 except NetMikoTimeoutException:
     print ('\n #### Device not reachable #### \n')
-    #continue
 except AuthenticationException:
     print ('\n #### Authentication Failure #### \n')
-    #continue
 except SSHException:
     print ('\n #### Check to see if SSH is enabled on device #### \n')
-    #continue
 
 print ('\n #### Connection successful, enabling vPC related features... #### \n')
 


### PR DESCRIPTION
## Summary
- remove stray `#continue` lines from the exception block

## Testing
- `python -m py_compile script_vpc_config_per_peer.py`


------
https://chatgpt.com/codex/tasks/task_e_6856ad0e9644832bb23e681ca48049c4